### PR TITLE
volatility updates

### DIFF
--- a/src/ChainlinkPriceOracle.sol
+++ b/src/ChainlinkPriceOracle.sol
@@ -43,7 +43,7 @@ contract ChainlinkPriceOracle is IPriceOracle, IChainlinkPriceOracleAdmin, Admin
     /// @inheritdoc IChainlinkPriceOracleAdmin
     function setPriceFeed(IERC20 token, AggregatorV3Interface priceFeed)
         external
-        requiresAdmin(msg.sender)
+        requiresAdmin
         returns (address, address)
     {
         // todo: validate token and price feed

--- a/src/UniswapV3VolatilityOracle.sol
+++ b/src/UniswapV3VolatilityOracle.sol
@@ -300,7 +300,7 @@ contract UniswapV3VolatilityOracle is IUniswapV3VolatilityOracle, Keep3rV2Job {
         Volatility.PoolMetadata memory poolMetadata = cachedPoolMetadata[_pool];
 
         uint32 secondsAgo = poolMetadata.maxSecondsAgo;
-        require(secondsAgo >= 1 hours, "Aloe: need more data");
+        require(secondsAgo >= 1 hours, "IV Oracle: need more data");
         if (secondsAgo > 1 days) {
             secondsAgo = 1 days;
         }

--- a/src/UniswapV3VolatilityOracle.sol
+++ b/src/UniswapV3VolatilityOracle.sol
@@ -117,7 +117,7 @@ contract UniswapV3VolatilityOracle is IUniswapV3VolatilityOracle, Keep3rV2Job {
     /// @inheritdoc IUniswapV3VolatilityOracle
     function refreshVolatilityCacheAndMetadataForPool(UniswapV3PoolInfo calldata info)
         public
-        requiresAdmin(msg.sender)
+        requiresAdmin
         returns (uint256)
     {
         _refreshPoolMetadata(info);
@@ -128,7 +128,7 @@ contract UniswapV3VolatilityOracle is IUniswapV3VolatilityOracle, Keep3rV2Job {
     /// @inheritdoc IUniswapV3VolatilityOracle
     function setDefaultFeeTierForTokenPair(address tokenA, address tokenB, UniswapV3FeeTier tier)
         external
-        requiresAdmin(msg.sender)
+        requiresAdmin
         returns (address, address, UniswapV3FeeTier)
     {
         if (tokenA == address(0) || tokenB == address(0)) {
@@ -144,7 +144,7 @@ contract UniswapV3VolatilityOracle is IUniswapV3VolatilityOracle, Keep3rV2Job {
     }
 
     /// @inheritdoc IUniswapV3VolatilityOracle
-    function cacheMetadataFor(IUniswapV3Pool pool) public requiresAdmin(msg.sender) {
+    function cacheMetadataFor(IUniswapV3Pool pool) public requiresAdmin {
         _cacheMetadataFor(pool);
     }
 
@@ -191,7 +191,7 @@ contract UniswapV3VolatilityOracle is IUniswapV3VolatilityOracle, Keep3rV2Job {
     /// @inheritdoc IUniswapV3VolatilityOracle
     function setTokenFeeTierRefreshList(UniswapV3PoolInfo[] calldata list)
         external
-        requiresAdmin(msg.sender)
+        requiresAdmin
         returns (UniswapV3PoolInfo[] memory)
     {
         delete tokenFeeTierList;

--- a/src/interfaces/IUniswapV3VolatilityOracle.sol
+++ b/src/interfaces/IUniswapV3VolatilityOracle.sol
@@ -128,6 +128,7 @@ interface IUniswapV3VolatilityOracle is IKeep3rV2Job, IAdmin, IVolatilityOracle 
 
     /**
      * @notice Updates the cached implied volatility for the supplied pool info.
+     * @param info The UniswapV3Pool info corresponding to the pool to refresh.
      * @return timestamp The timestamp of the cache refresh.
      */
     function refreshVolatilityCacheAndMetadataForPool(UniswapV3PoolInfo calldata info)

--- a/src/interfaces/IVolatilityOracle.sol
+++ b/src/interfaces/IVolatilityOracle.sol
@@ -9,13 +9,6 @@ pragma solidity 0.8.13;
  * by being wrapped in a contract implementing this interface.
  */
 interface IVolatilityOracle {
-    enum UniswapV3FeeTier {
-        PCT_POINT_01,
-        PCT_POINT_05,
-        PCT_POINT_3,
-        PCT_1
-    }
-
     /**
      * @notice Retrieves the historical volatility of a ERC20 token.
      * @param token The ERC20 token for which to retrieve historical volatility.
@@ -27,18 +20,14 @@ interface IVolatilityOracle {
      * @notice Retrieves the implied volatility of a ERC20 token.
      * @param tokenA The ERC20 token for which to retrieve historical volatility.
      * @param tokenB The ERC20 token for which to retrieve historical volatility.
-     * @param tier The Uniswap fee tier for the desired pool on which to derive a
      * volatility measurement.
-     * @return impliedVolatility The implied volatility of the token, scaled by 1e18
+     * @return impliedVolatility The implied volatility of the token, scaled by scale()
      */
-    function getImpliedVolatility(address tokenA, address tokenB, UniswapV3FeeTier tier)
-        external
-        view
-        returns (uint256 impliedVolatility);
+    function getImpliedVolatility(address tokenA, address tokenB) external view returns (uint256 impliedVolatility);
 
     /**
      * @notice Returns the scaling factor for the volatility
      * @return scale The power of 10 by which the return is scaled
      */
-    function scale() external view returns (uint16 scale);
+    function scale() external view returns (uint8 scale);
 }

--- a/src/utils/Admin.sol
+++ b/src/utils/Admin.sol
@@ -6,12 +6,12 @@ import "../interfaces/IAdmin.sol";
 abstract contract Admin is IAdmin {
     address internal admin;
 
-    modifier requiresAdmin(address sender) {
-        require(sender == admin, "!ADMIN");
+    modifier requiresAdmin() {
+        require(msg.sender == admin, "!ADMIN");
         _;
     }
 
-    function setAdmin(address _admin) external requiresAdmin(msg.sender) {
+    function setAdmin(address _admin) external requiresAdmin {
         require(_admin != address(0x0), "INVALID ADMIN");
         admin = _admin;
         emit AdminSet(_admin);

--- a/src/utils/Keep3rV2Job.sol
+++ b/src/utils/Keep3rV2Job.sol
@@ -16,7 +16,7 @@ abstract contract Keep3rV2Job is IKeep3rV2Job, Admin {
         IKeep3r(keep3r).worked(_keeper);
     }
 
-    function setKeep3r(address _keep3r) public requiresAdmin(msg.sender) {
+    function setKeep3r(address _keep3r) public requiresAdmin {
         _setKeep3r(_keep3r);
     }
 

--- a/test/UniswapV3VolatilityOracle.t.sol
+++ b/test/UniswapV3VolatilityOracle.t.sol
@@ -99,6 +99,11 @@ contract UniswapV3VolatilityOracleTest is Test, IUniswapV3SwapCallback {
         vm.expectRevert(bytes("!ADMIN"));
         oracle.setTokenFeeTierRefreshList(defaultTokenRefreshList);
 
+        vm.expectRevert(bytes("!ADMIN"));
+        oracle.setDefaultFeeTierForTokenPair(
+            USDC_ADDRESS, DAI_ADDRESS, IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_3
+        );
+
         // USDC-USDT
         IUniswapV3Pool pool = IUniswapV3Pool(0x3416cF6C708Da44DB2624D63ea0AAef7113527C6);
         vm.expectRevert(bytes("!ADMIN"));
@@ -164,6 +169,34 @@ contract UniswapV3VolatilityOracleTest is Test, IUniswapV3SwapCallback {
         vm.mockCall(KEEP3R_ADDRESS, abi.encodeWithSelector(IKeep3rJobWorkable.isKeeper.selector), abi.encode(true));
         vm.mockCall(KEEP3R_ADDRESS, abi.encodeWithSelector(IKeep3rJobWorkable.worked.selector), abi.encode(""));
         oracle.work();
+    }
+
+    function testDefaultFeeTierManagement() public {
+        // default fee tier should be uninitialized
+        IUniswapV3VolatilityOracle.UniswapV3FeeTier tier =
+            oracle.getDefaultFeeTierForTokenPair(USDC_ADDRESS, DAI_ADDRESS);
+        assertEq(uint256(tier), uint256(IUniswapV3VolatilityOracle.UniswapV3FeeTier.RESERVED));
+
+        // calling getIV without specifing a default fee tier for a token pair should revert
+        vm.expectRevert(IUniswapV3VolatilityOracle.NoFeeTierSpecifiedForTokenPair.selector);
+        oracle.getImpliedVolatility(USDC_ADDRESS, DAI_ADDRESS);
+
+        // assert the token pair is stored
+        oracle.setDefaultFeeTierForTokenPair(
+            USDC_ADDRESS, DAI_ADDRESS, IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_01
+        );
+        tier = oracle.getDefaultFeeTierForTokenPair(USDC_ADDRESS, DAI_ADDRESS);
+        assertEq(uint256(tier), uint256(IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_01));
+
+        oracle.setDefaultFeeTierForTokenPair(
+            USDC_ADDRESS, DAI_ADDRESS, IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_05
+        );
+        tier = oracle.getDefaultFeeTierForTokenPair(USDC_ADDRESS, DAI_ADDRESS);
+        assertEq(uint256(tier), uint256(IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_05));
+
+        // assert that the value is used for get IV
+        vm.expectRevert(bytes("Aloe: need more data"));
+        oracle.getImpliedVolatility(USDC_ADDRESS, DAI_ADDRESS);
     }
 
     /**

--- a/test/UniswapV3VolatilityOracle.t.sol
+++ b/test/UniswapV3VolatilityOracle.t.sol
@@ -195,7 +195,7 @@ contract UniswapV3VolatilityOracleTest is Test, IUniswapV3SwapCallback {
         assertEq(uint256(tier), uint256(IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_05));
 
         // assert that the value is used for get IV
-        vm.expectRevert(bytes("Aloe: need more data"));
+        vm.expectRevert(bytes("IV Oracle: need more data"));
         oracle.getImpliedVolatility(USDC_ADDRESS, DAI_ADDRESS);
     }
 

--- a/test/UniswapV3VolatilityOracle.t.sol
+++ b/test/UniswapV3VolatilityOracle.t.sol
@@ -65,17 +65,17 @@ contract UniswapV3VolatilityOracleTest is Test, IUniswapV3SwapCallback {
         delete defaultTokenRefreshList;
         defaultTokenRefreshList.push(
             IUniswapV3VolatilityOracle.UniswapV3PoolInfo(
-                USDC_ADDRESS, DAI_ADDRESS, IVolatilityOracle.UniswapV3FeeTier.PCT_POINT_01
+                USDC_ADDRESS, DAI_ADDRESS, IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_01
             )
         );
         defaultTokenRefreshList.push(
             IUniswapV3VolatilityOracle.UniswapV3PoolInfo(
-                FUN_ADDRESS, DAI_ADDRESS, IVolatilityOracle.UniswapV3FeeTier.PCT_POINT_01
+                FUN_ADDRESS, DAI_ADDRESS, IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_01
             )
         );
         defaultTokenRefreshList.push(
             IUniswapV3VolatilityOracle.UniswapV3PoolInfo(
-                WETH_ADDRESS, DAI_ADDRESS, IVolatilityOracle.UniswapV3FeeTier.PCT_POINT_3
+                WETH_ADDRESS, DAI_ADDRESS, IUniswapV3VolatilityOracle.UniswapV3FeeTier.PCT_POINT_3
             )
         );
     }


### PR DESCRIPTION
- Remove UniswapV3 specifics from IVolatilityOracle interface
- Implement default fee tier per token pair management in UniswapV3VolatilityOracle
- Associated tests